### PR TITLE
Option to leave a symlink behind after moving files (--symlink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ ./pddcat
 ### USAGE
 ```
 $ ./pddcat [-h] [-i] [-l] [-s path] [-d path] [-w] [-ts path] [-td path]
-              [-c] [-a name [name ...]]
+           [-c] [-a name [name ...]]
 
 Organise your all-in-one porn download directory into separate directories by model names.
 
@@ -24,8 +24,9 @@ optional arguments:
   -i, --info            print currently set src/dest directories and exit. can
                         be combined with -w, -ts, -td to display paths with
                         modifiers. terminates the program nonetheless
-  -l, --symlink         create symlinks/shortcuts after moving in the source
-                        directory
+  -l, --symlink         create symlinks/shortcuts after moving, in the source
+                        directory. needs command line to be run as admin on
+                        windows for symlink privileges
 
 config options:
   -s path, --source path
@@ -61,7 +62,8 @@ You can comment new names to [topic #9](https://github.com/kittenparry/pddcat/is
  * `~/dwn/bryci_youtube_playlist/` --> `~/arch/bryci/bryci_youtube_playlist/`
  * Meaning into their separate directories based on name.
  * `~/dwn/18.02.25.Lana.Rhoades.And.Jade.Nile.XXX.1080p/` --> `~/arch/lana_rhoades/18.02.25.Lana.Rhoades.And.Jade.Nile.XXX.1080p/`
-   * `lana_rhoades` is longer than `jade_nile` in character length and gets checked, matched & moved to first. If using `-l/--symlink` option, second model's !TODO:
+   * `lana_rhoades` is longer than `jade_nile` in character length and gets checked, matched & moved to first.
+   * If using `-l/--symlink` option, a symlink to the content will be put into second or third... model's directory, partially solving #4.
 
 ### NOTES
 An uncorrectable shortcoming is it can't tell the difference between models with different names, for example `Nadya Nabakova` and `Bunny Colby` are the same person with different names/aliases. Depending on the file/directory name, it will put them into separate directories.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ $ ./pddcat
 
 ### USAGE
 ```
-$ ./pddcat [-h] [-i] [-s path] [-d path] [-w] [-ts path] [-td path] [-c] [-a name [name ...]]
+$ ./pddcat [-h] [-i] [-l] [-s path] [-d path] [-w] [-ts path] [-td path]
+              [-c] [-a name [name ...]]
 
 Organise your all-in-one porn download directory into separate directories by model names.
 
@@ -23,6 +24,8 @@ optional arguments:
   -i, --info            print currently set src/dest directories and exit. can
                         be combined with -w, -ts, -td to display paths with
                         modifiers. terminates the program nonetheless
+  -l, --symlink         create symlinks/shortcuts after moving in the source
+                        directory
 
 config options:
   -s path, --source path
@@ -58,7 +61,7 @@ You can comment new names to [topic #9](https://github.com/kittenparry/pddcat/is
  * `~/dwn/bryci_youtube_playlist/` --> `~/arch/bryci/bryci_youtube_playlist/`
  * Meaning into their separate directories based on name.
  * `~/dwn/18.02.25.Lana.Rhoades.And.Jade.Nile.XXX.1080p/` --> `~/arch/lana_rhoades/18.02.25.Lana.Rhoades.And.Jade.Nile.XXX.1080p/`
-   * `lana_rhoades` is longer than `jade_nile` in character length and gets checked, matched & moved to first. See [issue #4](https://github.com/kittenparry/pddcat/issues/4) for multiple models moving.
+   * `lana_rhoades` is longer than `jade_nile` in character length and gets checked, matched & moved to first. If using `-l/--symlink` option, second model's !TODO:
 
 ### NOTES
 An uncorrectable shortcoming is it can't tell the difference between models with different names, for example `Nadya Nabakova` and `Bunny Colby` are the same person with different names/aliases. Depending on the file/directory name, it will put them into separate directories.

--- a/pddcat
+++ b/pddcat
@@ -52,7 +52,6 @@ CONF_CONT = '# src=path/to/src\n# dest=path/to/dest\n# Tilde (~) could be used i
 
 # symlinks toggle
 SYMS = False
-SYMS_MULTI = False
 
 # ---
 # START
@@ -66,10 +65,7 @@ def start():
 		help='print currently set src/dest directories and exit. can be combined with -w, -ts, -td to display paths with modifiers. terminates the program nonetheless',
 		action='store_true')
 	parser.add_argument('-l', '--symlink',
-		help='create symlinks/shortcuts after moving in the source directory. can not be combined with -m',
-		action='store_true')
-	parser.add_argument('-m', '--multi-only',
-		help='create symlinks for multiple model content only. can not be combined with -l',
+		help='create symlinks/shortcuts after moving, in the source directory. needs command line to be run as admin on windows for symlink privileges',
 		action='store_true')
 
 	group_config = parser.add_argument_group('config options')
@@ -104,14 +100,8 @@ def start():
 	if args.symlink:
 		global SYMS
 		SYMS = args.symlink
-	elif args.multi_only:
-		global SYMS_MULTI
-		SYMS_MULTI = args.multi_only
-	if args.symlink and args.multi_only:
-		print('%sERROR%s: -l & -m can not be combined with each other. Terminating...' % (COL.FAIL, COL.ENDC))
-		sys.exit(1)
 
-	if len(sys.argv) == 1 or (len(sys.argv) == 2 and args.symlink) or (len(sys.argv) == 2 and args.multi_only):
+	if len(sys.argv) == 1 or (len(sys.argv) == 2 and args.symlink):
 		check_and_move()
 	else:
 		if args.working_dir and args.temp_src:
@@ -387,15 +377,15 @@ def move_dirs():
 					dir_or_file = 'ELSE??'
 
 				if dir_or_file == 'ELSE??':
-					print('%sWARNING%s: Multiple model directories/files only get moved to one directory\n%sUnless%s using -l\--symlink option.' % (COL.WARNING, COL.ENDC, COL.UNDERLINE, COL.ENDC))
+					print('%sWARNING%s: Multiple model directories/files only get moved to one directory\n%sUnless%s using -l/--symlink option.' % (COL.WARNING, COL.ENDC, COL.UNDERLINE, COL.ENDC))
 					continue
 				print('Moving %s: %s.' % (dir_or_file, down))
 				try:
 					# turn regex back to normal directory names
 					tag = tag.replace('[\. _-]*', '_')
-					global SYMS
 					os.makedirs(os.path.join(DEST_DIR, tag), exist_ok=True)
 					shutil.move(full_path, os.path.join(DEST_DIR, tag, down))
+					global SYMS
 					if SYMS:
 						os.symlink(os.path.join(DEST_DIR, tag, down), full_path)
 				except Exception as e:

--- a/pddcat
+++ b/pddcat
@@ -50,6 +50,10 @@ class COL:
 CONF_CONT = '# src=path/to/src\n# dest=path/to/dest\n# Tilde (~) could be used instead of absolute path to home.\n' \
 	'# Check --help to set up from command line\nsrc=%s\ndest=%s\n'
 
+# symlinks toggle
+SYMS = False
+SYMS_MULTI = False
+
 # ---
 # START
 # ---
@@ -60,6 +64,12 @@ def start():
 	parser = argparse.ArgumentParser(description='Organise your all-in-one porn download directory into separate directories by model names.')
 	parser.add_argument('-i', '--info',
 		help='print currently set src/dest directories and exit. can be combined with -w, -ts, -td to display paths with modifiers. terminates the program nonetheless',
+		action='store_true')
+	parser.add_argument('-l', '--symlink',
+		help='create symlinks/shortcuts after moving in the source directory. can not be combined with -m',
+		action='store_true')
+	parser.add_argument('-m', '--multi-only',
+		help='create symlinks for multiple model content only. can not be combined with -l',
 		action='store_true')
 
 	group_config = parser.add_argument_group('config options')
@@ -91,7 +101,17 @@ def start():
 
 	args = parser.parse_args()
 	read_conf()
-	if len(sys.argv) == 1:
+	if args.symlink:
+		global SYMS
+		SYMS = args.symlink
+	elif args.multi_only:
+		global SYMS_MULTI
+		SYMS_MULTI = args.multi_only
+	if args.symlink and args.multi_only:
+		print('%sERROR%s: -l & -m can not be combined with each other. Terminating...' % (COL.FAIL, COL.ENDC))
+		sys.exit(1)
+
+	if len(sys.argv) == 1 or (len(sys.argv) == 2 and args.symlink) or (len(sys.argv) == 2 and args.multi_only):
 		check_and_move()
 	else:
 		if args.working_dir and args.temp_src:
@@ -357,7 +377,9 @@ def move_dirs():
 			for down in match:
 				num_of_mv += 1
 				full_path = os.path.join(DWN_DIR, down)
-				if os.path.isdir(full_path):
+				if os.path.islink(full_path):
+					dir_or_file = 'SYMLINK'
+				elif os.path.isdir(full_path):
 					dir_or_file = 'DIR'
 				elif os.path.isfile(full_path):
 					dir_or_file = 'FILE'
@@ -365,15 +387,17 @@ def move_dirs():
 					dir_or_file = 'ELSE??'
 
 				if dir_or_file == 'ELSE??':
-					print('%sWARNING%s: Multiple model directories/files only get moved to one directory.' \
-						' See issue #4 on GitHub.' % (COL.WARNING, COL.ENDC))
+					print('%sWARNING%s: Multiple model directories/files only get moved to one directory\n%sUnless%s using -l\--symlink option.' % (COL.WARNING, COL.ENDC, COL.UNDERLINE, COL.ENDC))
 					continue
 				print('Moving %s: %s.' % (dir_or_file, down))
 				try:
 					# turn regex back to normal directory names
 					tag = tag.replace('[\. _-]*', '_')
+					global SYMS
 					os.makedirs(os.path.join(DEST_DIR, tag), exist_ok=True)
 					shutil.move(full_path, os.path.join(DEST_DIR, tag, down))
+					if SYMS:
+						os.symlink(os.path.join(DEST_DIR, tag, down), full_path)
 				except Exception as e:
 					prn_gen_err(e)
 


### PR DESCRIPTION
Also moves a symlink(s) to additional model directories if content includes multiple models (somewhat solving #4).